### PR TITLE
Add attempt at caching

### DIFF
--- a/quantum_systems/quantum_dots/two_dim/two_dim_ho.py
+++ b/quantum_systems/quantum_dots/two_dim/two_dim_ho.py
@@ -78,9 +78,11 @@ class TwoDimensionalHarmonicOscillator(QuantumSystem):
         self.radius = np.linspace(0, self.radius_length, self.num_grid_points)
         self.theta = np.linspace(0, 2 * np.pi, self.num_grid_points)
 
-    def setup_system(self, add_spin=True, anti_symmetrize=True):
+    def setup_system(self, add_spin=True, anti_symmetrize=True, verbose=True):
         self._h = self.omega * get_one_body_elements(self.l // 2)
-        self._u = np.sqrt(self.omega) * get_coulomb_elements(self.l // 2)
+        self._u = np.sqrt(self.omega) * get_coulomb_elements(
+            self.l // 2, verbose=verbose
+        )
         self._s = np.eye(self.l // 2)
 
         self.setup_spf()

--- a/tests/test_two_dim_ho.py
+++ b/tests/test_two_dim_ho.py
@@ -1,3 +1,5 @@
+import os
+import sys
 import pytest
 import numpy as np
 
@@ -27,6 +29,27 @@ def test_two_body_symmetry():
             for r in range(l):
                 for s in range(l):
                     assert abs(u[p, q, r, s] - u[q, p, s, r]) < 1e-8
+
+
+def test_tdho_caching():
+    l = 12
+
+    pre_cache = os.listdir()
+
+    os.environ["QS_CACHE_TDHO"] = "1"
+    u = get_coulomb_elements(l)
+
+    post_cache = os.listdir()
+
+    assert len(set(post_cache) - set(pre_cache)) == 1
+
+    u_2 = get_coulomb_elements(l)
+    np.testing.assert_allclose(u, u_2)
+
+    filename = (set(post_cache) - set(pre_cache)).pop()
+    os.remove(filename)
+
+    assert len(set(os.listdir()) - set(pre_cache)) == 0
 
 
 def test_p_index(index_map):


### PR DESCRIPTION
This is an attempt at solving #11 by using `np.save` and `np.load` to cache Coulomb elements for the two-dimensional harmonic oscillator. It is at the moment quite hacky, but it seems to do the trick. To trigger caching, export the environment variable `QS_CACHE_TDHO`, viz.
```bash
export QS_CACHE_TDHO='1'
```
Currently the value is insignificant as the program only checks if there is _any_ variable. So, for instance the following variables will also trigger caching:
```bash
export QS_CACHE_TDHO=`DEAR GOD NO CACHING`
```
and
```bash
export QS_CACHE_TDHO=`PLEASE TURN OFF CACHING`
```
and
```bash
export QS_CACHE_TDHO=`WHERE ARE ALL THE BLOODY FILES AND WHAT HAVE YOU DONE TO MY MEMORY`
```
The files are stored in the working directory of the script calling the setup of the Coulomb elements, so typically from where the solver script is run. Files are in the `.npy` format and typically a quick
```bash
rm /path/to/script/*.npy
```
will remove all the cached elements. I've also added an extre `verbose` argument to the `TwoDimensionalHarmonicOscillator.setup_system` function which will let you know when caching occurs and also time the setup of the Coulomb elements.