### PR TITLE
Support frozen core

### DIFF
--- a/quantum_systems/custom_system.py
+++ b/quantum_systems/custom_system.py
@@ -111,6 +111,7 @@ def construct_pyscf_system_rhf(
     verbose=False,
     charge=0,
     cart=False,
+    nfrozen=0,
     **kwargs,
 ):
     """Convenience function setting up a closed-shell atom or a molecule from
@@ -215,7 +216,7 @@ def construct_pyscf_system_rhf(
     bs.dipole_moment = dipole_integrals
     bs.change_module(np=np)
 
-    system = SpatialOrbitalSystem(n, bs)
+    system = SpatialOrbitalSystem(n, bs, nfrozen=nfrozen)
     system.change_basis(C)
 
     return (

--- a/quantum_systems/general_orbital_system.py
+++ b/quantum_systems/general_orbital_system.py
@@ -55,7 +55,7 @@ class GeneralOrbitalSystem(QuantumSystem):
             The reference energy.
         """
 
-        o, v = self.o, self.v
+        o, v = slice(0, self.n), self.v
 
         return self.np.trace(self.h[o, o]) + 0.5 * self.np.trace(
             self.np.trace(self.u[o, o, o, o], axis1=1, axis2=3)
@@ -91,7 +91,7 @@ class GeneralOrbitalSystem(QuantumSystem):
         """
 
         np = self.np
-        o, v = (self.o, self.v)
+        o, v = (slice(0, self.n), self.v)
 
         if f is None:
             f = np.zeros_like(h)

--- a/quantum_systems/spatial_orbital_system.py
+++ b/quantum_systems/spatial_orbital_system.py
@@ -109,7 +109,7 @@ class SpatialOrbitalSystem(QuantumSystem):
             The reference energy.
         """
 
-        o, v = self.o, self.v
+        o, v = slice(0, self.n), self.v
 
         return (
             2 * self.np.trace(self.h[o, o])
@@ -147,7 +147,7 @@ class SpatialOrbitalSystem(QuantumSystem):
             The filled Fock matrix.
         """
         np = self.np
-        o, v = (self.o, self.v)
+        o, v = (slice(0, self.n), self.v)
 
         if f is None:
             f = np.zeros_like(h)

--- a/quantum_systems/system.py
+++ b/quantum_systems/system.py
@@ -16,17 +16,17 @@ class QuantumSystem(metaclass=abc.ABCMeta):
         states.
     """
 
-    def __init__(self, n, basis_set):
+    def __init__(self, n, basis_set, nfrozen=0):
         self._basis_set = basis_set
 
         assert n <= self._basis_set.l
 
         self.np = self._basis_set.np
-        self.set_system_size(n, self._basis_set.l)
+        self.set_system_size(n, self._basis_set.l, nfrozen)
 
         self._time_evolution_operator = None
 
-    def set_system_size(self, n, l):
+    def set_system_size(self, n, l, nfrozen):
         """Function setting the system size. Note that ``l`` should
         correspond to the length of each axis of the matrix elements.
 
@@ -43,8 +43,9 @@ class QuantumSystem(metaclass=abc.ABCMeta):
         self.n = n
         self.l = l
         self.m = self.l - self.n
+        self.nfrozen = nfrozen
 
-        self.o = slice(0, self.n)
+        self.o = slice(nfrozen, self.n)
         self.v = slice(self.n, self.l)
 
     @abc.abstractmethod
@@ -65,7 +66,7 @@ class QuantumSystem(metaclass=abc.ABCMeta):
 
     def change_basis(self, C, C_tilde=None):
         self._basis_set.change_basis(C, C_tilde)
-        self.set_system_size(self.n, self._basis_set.l)
+        self.set_system_size(self.n, self._basis_set.l, self.nfrozen)
 
     @abc.abstractmethod
     def change_to_hf_basis(self, *args, **kwargs):


### PR DESCRIPTION
This pull requests allows for frozen core orbitals. This is implemented by modifying the slice for occupied orbitals:
   self.o = slice(0,system.n) -> slice(nfrozen,system.n), 
where nfrozen now is an argument to the constructor of the system class. The parameter nfrozen just gives the number of electrons to freeze, so it does not discriminate between restricted or general type systems. This has the potential pitfall that, for example nfrozen=1 effectively freezes the lowest lying doubly occupied orbital for a restricted system, while freezing just 1 spin-orbital for a general system. We have support for going from a restricted to a general system, thus we should make a choice if this automatically should mean that nfrozen is multiplied by 2 (I think this is most sensible, but maybe it is debatable).

Note that system.n, system.l and system.m are unchanged and that the number of virtual orbitals (self.m) is unaffected by the frozen core. However, it should be noted that when the reference energy and the fock matrix is constructed all occupied orbitals have to be used. This is handled explicitly in these methods. 