### PR TITLE
Use Python 3.8 when testing on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
-    - "3.6"
-    - "3.7"
+    - "3.8"
 install:
     - pip install pipenv
     - pipenv install --skip-lock


### PR DESCRIPTION
This avoids the installation bugs for Python 3.7 when combining NumPy and Pandas.