### PR TITLE
More efficient _compute_inner_integral

### DIFF
--- a/quantum_systems/quantum_dots/one_dim/one_dim_qd.py
+++ b/quantum_systems/quantum_dots/one_dim/one_dim_qd.py
@@ -37,15 +37,13 @@ def _shielded_coulomb(x_1, x_2, alpha, a):
 @numba.njit(cache=True)
 def _compute_inner_integral(spf, l, num_grid_points, grid, alpha, a):
     inner_integral = np.zeros((l, l, num_grid_points), dtype=np.complex128)
-    
+
     for i in range(num_grid_points):
         coulomb = _shielded_coulomb(grid[i], grid, alpha, a)
         for q in range(l):
             for s in range(l):
                 inner_integral[q, s, i] = _trapz(
-                    np.conjugate(spf[q])
-                    * coulomb
-                    * spf[s],
+                    np.conjugate(spf[q]) * coulomb * spf[s],
                     grid,
                 )
 

--- a/quantum_systems/quantum_dots/one_dim/one_dim_qd.py
+++ b/quantum_systems/quantum_dots/one_dim/one_dim_qd.py
@@ -37,13 +37,14 @@ def _shielded_coulomb(x_1, x_2, alpha, a):
 @numba.njit(cache=True)
 def _compute_inner_integral(spf, l, num_grid_points, grid, alpha, a):
     inner_integral = np.zeros((l, l, num_grid_points), dtype=np.complex128)
-
-    for q in range(l):
-        for s in range(l):
-            for i in range(num_grid_points):
+    
+    for i in range(num_grid_points):
+        coulomb = _shielded_coulomb(grid[i], grid, alpha, a)
+        for q in range(l):
+            for s in range(l):
                 inner_integral[q, s, i] = _trapz(
                     np.conjugate(spf[q])
-                    * _shielded_coulomb(grid[i], grid, alpha, a)
+                    * coulomb
                     * spf[s],
                     grid,
                 )


### PR DESCRIPTION
The coulomb force only needs to be evaluated on the grid once for each q and s, so it is a lot faster to loop over the grid once than l*l times.